### PR TITLE
New hooks v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1299,9 +1299,9 @@
       }
     },
     "ketting": {
-      "version": "6.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/ketting/-/ketting-6.0.0-alpha.5.tgz",
-      "integrity": "sha512-IWxh+czh0qn9CsAEnal2ur8Xz09fzbf+byN3mVgScWNgFoyWSocBttBSmKXdLROloxuz2ZgJH0/ngjB6+itfaA==",
+      "version": "6.0.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/ketting/-/ketting-6.0.0-alpha.7.tgz",
+      "integrity": "sha512-gLbHWMNJyzEqr/U2B+dov/XCrJyl7ai4CQIHk9Amx2IEnQooo9xBmF/2GOj65AIr3pb/qHx8eC8knPMLV1VZCg==",
       "dev": true,
       "requires": {
         "fetch-mw-oauth2": "^0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "types": "dist/index.d.ts",
   "peerDependencies": {
     "react": "^16.13.1",
-    "ketting": "^6.0.0-alpha.5"
+    "ketting": "^6.0.0-alpha.7"
   },
   "devDependencies": {
     "@types/chai": "^4.2.10",
@@ -45,7 +45,7 @@
     "@types/node": "^12.12.45",
     "@types/react": "^16.9.35",
     "chai": "^4.2.0",
-    "ketting": "^6.0.0-alpha.5",
+    "ketting": "^6.0.0-alpha.7",
     "mocha": "^7.2.0",
     "nyc": "^15.1.0",
     "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "browser": "browser/react-ketting.min.js",

--- a/src/hooks/use-read-resource.ts
+++ b/src/hooks/use-read-resource.ts
@@ -58,7 +58,7 @@ export function useReadResource<T>(resource: Resource<T>): UseReadResourceResult
 
   useEffect(() => {
 
-    const onUpdate = useRef((state: State<T>) {
+    const onUpdate = useRef((state: ResourceState<T>) => {
       if (isMounted.current) {
         setResourceState(state);
       }
@@ -72,17 +72,19 @@ export function useReadResource<T>(resource: Resource<T>): UseReadResourceResult
 
       resource.on('update', onUpdate.current);
 
-    }).catch(err => {
+    })().catch(err => {
 
       setLoading(false);
       setError(err);
 
-    }, () => {
+    })
+
+    return function cleanup() {
 
       isMounted.current = false;
-      resource.off(onUpdate.current);
+      resource.off('update', onUpdate.current);
 
-    });
+    };
 
   }, [resource]);
 

--- a/src/hooks/use-read-resource.ts
+++ b/src/hooks/use-read-resource.ts
@@ -7,6 +7,35 @@ type UseReadResourceResult<T> = {
   resourceState: ResourceState<T>
 }
 
+/**
+ * Hook for fetching and subscribing to state changes on Ketting resources.
+ *
+ * The hook returns an object with three properties:
+ * 1. loading (boolean)
+ * 2. error (Error|null)
+ * 3. resourceState - A ketting State object.
+ *
+ * The hook will automatically update its internal state if Ketting received
+ * 'update' events.
+ *
+ * Example usage:
+ *
+ * <pre>
+ *  function MyComponent(resource: Resource<Article>) {
+ *
+ *     const {loading, error, resourceState} = useReadResource(resource);
+ *     if (loading) return <p>Loading...</p>;
+ *     if (error) return <div class="error">Error: ${err.message}</div>
+ *
+ *     return <article>
+ *       <h1>${resourceState.title}</h1>
+ *       <p>${resoourceState.body}</p>
+ *     </article>;
+ *
+ *  }
+ * </pre>
+ *
+ */
 export function useReadResource<T>(resource: Resource<T>): UseReadResourceResult<T> {
 
   const [loading, setLoading] = useState(true);

--- a/src/hooks/use-read-resource.ts
+++ b/src/hooks/use-read-resource.ts
@@ -2,8 +2,20 @@ import { useState, useEffect, useRef } from 'react';
 import { Resource, State as ResourceState } from 'ketting';
 
 type UseReadResourceResult<T> = {
+
+  /**
+   * 'true' if resource has not yet been fetched from the server.
+   */
   loading: boolean,
+
+  /**
+   * Contains an Error object when an operation has failed.
+   */
   error: Error|null,
+
+  /**
+   * Full Ketting 'State' object.
+   */
   resourceState: ResourceState<T>
 }
 

--- a/src/hooks/use-read-resource.ts
+++ b/src/hooks/use-read-resource.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useRef } from 'react';
+import { Resource, State as ResourceState } from 'ketting';
+
+type UseReadResourceResult<T> = {
+  loading: boolean,
+  error: Error|null,
+  resourceState: ResourceState<T>
+}
+
+export function useReadResource<T>(resource: Resource<T>): UseReadResourceResult<T> {
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error|null>(null);
+  const [resourceState, setResourceState] = useState<ResourceState<T>>();
+
+  const isMounted = useRef(true);
+
+  useEffect(() => {
+
+    const onUpdate = useRef((state: State<T>) {
+      if (isMounted.current) {
+        setResourceState(state);
+      }
+    });
+
+    (async() => {
+
+      const state = await resource.get();
+      setResourceState(state);
+      setLoading(false);
+
+      resource.on('update', onUpdate.current);
+
+    }).catch(err => {
+
+      setLoading(false);
+      setError(err);
+
+    }, () => {
+
+      isMounted.current = false;
+      resource.off(onUpdate.current);
+
+    });
+
+  }, [resource]);
+
+  return {
+    loading,
+    error,
+    resourceState: resourceState as ResourceState<T>
+  }
+
+}

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -16,9 +16,32 @@ type UseResourceResponse<T> = {
 
 }
 
-export function useResource<T>(resource: Resource<T>, mode?: 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T>;
-export function useResource<T>(parentResource: Resource<any>, mode: 'POST', initialData: ResourceState<T>): UseResourceResponse<T>;
-export function useResource<T>(resource: Resource<any>, mode: 'POST' | 'PUT' = 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T> {
+type UseResourceOptions<T> = {
+  mode: 'PUT',
+  resource: Resource<T>,
+  initialState?: T | ResourceState<T>,
+} | {
+  mode: 'POST',
+  resource: Resource<any>,
+  initialState: T | ResourceState<T>,
+}
+
+export function useResource<T>(resource: Resource<T>): UseResourceResponse<T>;
+export function useResource<T>(options: UseResourceOptions<T>): UseResourceResponse<T>;
+export function useResource<T>(arg1: Resource<T>|UseResourceOptions<T>): UseResourceResponse<T> {
+
+  let resource: Resource<T>;
+  let mode : 'PUT' | 'POST';
+  let initialState: ResourceState<T> | T | undefined;
+  if (arg1 instanceof Resource) {
+    resource = arg1;
+    mode = 'PUT';
+    initialState = undefined;
+  } else {
+    resource = arg1.resource;
+    mode = arg1.mode;
+    initialState = arg1.initialState;
+  }
 
   const isMounted = useRef(true);
 
@@ -34,7 +57,7 @@ export function useResource<T>(resource: Resource<any>, mode: 'POST' | 'PUT' = '
         setResourceState(state);
       }
     }
-    lifecycle.current = new ResourceLifecycle(resource, mode, initialData, onUpdate);
+    lifecycle.current = new ResourceLifecycle(resource, mode, initialState, onUpdate);
 
     (async() => {
       setResourceState(await lifecycle.current!.getState());

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -26,6 +26,62 @@ type UseResourceOptions<T> = {
   initialState: T | ResourceState<T>,
 }
 
+/**
+ * The useResource hook allows you to GET and PUT the state of
+ * a resource.
+ *
+ * Example call:
+ *
+ * <pre>
+ *   const {
+ *     loading,
+ *     error,
+ *     resourceState,
+ *     setResourceState,
+ *     submit
+ *  } = useResource(resource);
+ * </pre>
+ * 
+ * Returned properties:
+ *
+ * * loading - will be true as long as the result is still being fetched from
+ *             the server.
+ * * error - Will be null or an error object.
+ * * resourceState - A state object. The `.data` property of this object will
+ *                   contain the parsed JSON from the server.
+ * * setResourceState - Update the local cache of the resource.
+ * * submit - Send a PUT request to the server.
+ *
+ * If you don't need the full resourceState, you can also use the `data` and
+ * `setData` properties instead of `resourceState` or `useResourceState`.
+ *
+ * It's also possible to use useResource for making new resources. In this case
+ * a POST request will be done instead on a 'collection' resource.
+ *
+ * If the response to the POST request is 201 Created and has a Location header,
+ * subsequent calls to `submit()` turn into `PUT` requests on the new resource,
+ * fully managing the lifecycle of creation, and subsequent updates to the
+ * resource.
+ *
+ * Example call:
+ *
+ * <pre>
+ *   const {
+ *     loading,
+ *     error,
+ *     data,
+ *     setData,
+ *     submit
+ *  } = useResource({
+ *    resource: resource,
+ *    mode: 'POST',
+ *    initialState: { foo: bar, title: 'New article!' }
+ *  });
+ * </pre>
+ *
+ * To do POST requests you must specifiy initialState with the state the user starts
+ * off with.
+ */
 export function useResource<T>(resource: Resource<T>): UseResourceResponse<T>;
 export function useResource<T>(options: UseResourceOptions<T>): UseResourceResponse<T>;
 export function useResource<T>(arg1: Resource<T>|UseResourceOptions<T>): UseResourceResponse<T> {

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -101,7 +101,6 @@ export function useResource<T>(resource: Resource<T>): UseResourceResult<T> {
 
   useEffect(() => {
 
-
     const onUpdateListener = (newState: State) => {
 
       updateResult(

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -63,8 +63,8 @@ export function useResource<T>(arg1: Resource<T>|UseResourceOptions<T>): UseReso
       setResourceState(await lifecycle.current!.getState());
       setLoading(false);
     })().catch(err => {
-      setLoading(false);
       setError(err);
+      setLoading(false);
     });
 
     return function cleanup() {

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -4,14 +4,23 @@ import ResourceLifecycle from '../resource-lifecycle';
 
 type UseResourceResponse<T> = {
 
+  // True if there is no data yet
   loading: boolean;
   error: Error | null;
 
+  // A full Ketting State object
   resourceState: ResourceState<T>;
+
+  // Update the state
   setResourceState: (newState: ResourceState<T>) => void;
+
+  // Send the state to the server via a PUT or POST request.
   submit: (state?: ResourceState<T>) => void;
 
+  // The 'data' part of the state.
   data: T;
+
+  // Update the data from the state.
   setData: (newData: T) => void;
 
 }
@@ -41,7 +50,7 @@ type UseResourceOptions<T> = {
  *     submit
  *  } = useResource(resource);
  * </pre>
- * 
+ *
  * Returned properties:
  *
  * * loading - will be true as long as the result is still being fetched from

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -54,7 +54,7 @@ export function useResource<T>(arg1: Resource<T>|UseResourceOptions<T>): UseReso
   useEffect( () => {
     const onUpdate = (state: ResourceState<T>) => {
       if (isMounted.current) {
-        setResourceState(state);
+        setResourceState(state.clone());
       }
     }
     lifecycle.current = new ResourceLifecycle(resource, mode, initialState, onUpdate);

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -16,9 +16,9 @@ type UseResourceResponse<T> = {
 
 }
 
-export function useResource<T>(resource: Resource, mode?: 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T>;
-export function useResource<T>(parentResource: Resource, mode: 'POST', initialData: ResourceState<T>): UseResourceResponse<T>;
-export function useResource<T>(resource: Resource, mode: 'POST' | 'PUT' = 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T> {
+export function useResource<T>(resource: Resource<T>, mode?: 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T>;
+export function useResource<T>(parentResource: Resource<T>, mode: 'POST', initialData: ResourceState<T>): UseResourceResponse<T>;
+export function useResource<T>(resource: Resource<T>, mode: 'POST' | 'PUT' = 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T> {
 
   const isMounted = useRef(true);
 

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -25,7 +25,7 @@ export function useResource<T>(resource: Resource, mode: 'POST' | 'PUT' = 'PUT',
   const [resourceState, setResourceState] = useState<ResourceState<T>|undefined>(initialData);
   const [loading, setLoading] = useState(resourceState !== undefined);
   const [error, setError] = useState<null|Error>(null);
-  
+
   const lifecycle = useRef<ResourceLifecycle<T>>();
 
   useEffect( () => {
@@ -35,7 +35,7 @@ export function useResource<T>(resource: Resource, mode: 'POST' | 'PUT' = 'PUT',
       }
     }
     lifecycle.current = new ResourceLifecycle(resource, mode, initialData, onUpdate);
-  
+
     (async() => {
       setResourceState(await lifecycle.current!.getState());
       setLoading(false);

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -17,12 +17,12 @@ type UseResourceResponse<T> = {
 }
 
 export function useResource<T>(resource: Resource<T>, mode?: 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T>;
-export function useResource<T>(parentResource: Resource<T>, mode: 'POST', initialData: ResourceState<T>): UseResourceResponse<T>;
-export function useResource<T>(resource: Resource<T>, mode: 'POST' | 'PUT' = 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T> {
+export function useResource<T>(parentResource: Resource<any>, mode: 'POST', initialData: ResourceState<T>): UseResourceResponse<T>;
+export function useResource<T>(resource: Resource<any>, mode: 'POST' | 'PUT' = 'PUT', initialData?: ResourceState<T>): UseResourceResponse<T> {
 
   const isMounted = useRef(true);
 
-  const [resourceState, setResourceState] = useState<ResourceState<T>|undefined>(initialData);
+  const [resourceState, setResourceState] = useState<ResourceState<T>>();
   const [loading, setLoading] = useState(resourceState !== undefined);
   const [error, setError] = useState<null|Error>(null);
 

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -46,7 +46,7 @@ export function useResource<T>(arg1: Resource<T>|UseResourceOptions<T>): UseReso
   const isMounted = useRef(true);
 
   const [resourceState, setResourceState] = useState<ResourceState<T>>();
-  const [loading, setLoading] = useState(resourceState !== undefined);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<null|Error>(null);
 
   const lifecycle = useRef<ResourceLifecycle<T>>();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
-export { useResource } from './hooks';
+export { useResource } from './hooks/use-resource';
+export { useReadResource } from './hooks/use-read-resource';
 export { withResource } from './hoc';

--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -66,7 +66,7 @@ export default class ResourceLifecycle<T> {
       this.currentState = await newResource.get();
       this.setupEvents();
     } else {
-      this.currentResource.put(this.currentState!);
+      await this.currentResource.put(this.currentState!);
     }
 
   }

--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -12,7 +12,7 @@ export default class ResourceLifecycle<T extends any> {
   currentState: State<T> | null;
   mode: 'PUT' | 'POST';
   currentResource: Resource<T>;
-  onUpdate: (newState: State<T>)=>void;
+  onUpdate: (newState: State<T>) => void;
 
   constructor(resource: Resource<T>, mode: 'PUT' | 'POST', initialState: State<T> | T | undefined, onUpdate: (state: State<T>) => void) {
 
@@ -29,9 +29,11 @@ export default class ResourceLifecycle<T extends any> {
     } else {
       this.currentState = dataToState(initialState) as State<T>;
     }
+    if (mode === 'PUT') {
+      this.setupEvents();
+    }
 
   }
-
 
   async getState(): Promise<State<T>> {
 

--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -1,0 +1,95 @@
+import { Resource, State, HalState, Links } from 'ketting';
+
+/**
+ * A utility class for managing state changes to resources.
+ *
+ * This class can handle submitting a POST request to create a ne
+ * resource, following a Location header and subsequent PUT
+ * requests.
+ */
+export default class ResourceLifecycle<T> {
+
+  currentState: State<T> | null;
+  mode: 'PUT' | 'POST';
+  currentResource: Resource<T>;
+
+  constructor(resource: Resource<T>, mode: 'PUT' | 'POST', initialState: State<T> | undefined, onUpdate: (state: State<T>) => void) {
+
+    if (mode==='POST' && !initialState) {
+      throw new Error('In POST mode you must specifiy the "initialState" parameter');
+    }
+    this.currentResource = resource;
+    this.mode = mode;
+    this.currentState = initialState || null;
+
+  }
+
+
+  async getState(): Promise<State<T>> {
+
+    if (this.currentState) {
+      return this.currentState;
+    }
+    return this.currentResource.get();
+
+  }
+
+  setState(state: State<T>): void {
+
+    this.currentState = state;
+    if (this.mode === 'PUT') {
+      // Update the Ketting cache too.
+      this.currentResource.updateCache(state);
+    }
+
+  }
+
+  setData(data: T): void {
+
+    this.currentState = new HalState(
+      'about:blank',
+      data,
+      new Headers(),
+      new Links(),
+      [],
+    );
+
+  }
+
+  async submit(): Promise<void> {
+
+    if (this.mode === 'POST') {
+      // Create new resource.
+      const newResource = await this.currentResource.postFollow(this.currentState!);
+      this.currentResource = newResource;
+      this.mode = 'PUT';
+      this.currentState = await newResource.get();
+      this.setupEvents();
+    } else {
+      this.currentResource.put(this.currentState!);
+    }
+
+  }
+
+  public cleanup() {
+
+    this.currentResource.off('update', this.onUpdate);
+
+  }
+
+  private setupEvents() {
+
+    if (this.mode === 'POST') {
+      throw new Error('Update events cannot be subscribed to before the resource exists');
+    }
+    this.currentResource.on('update', this.onUpdate);
+
+  }
+
+  private onUpdate(state: State<T>) {
+
+    this.currentState = state;
+
+  }
+
+}

--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -12,6 +12,7 @@ export default class ResourceLifecycle<T extends any> {
   currentState: State<T> | null;
   mode: 'PUT' | 'POST';
   currentResource: Resource<T>;
+  onUpdate: (newState: State<T>)=>void;
 
   constructor(resource: Resource<T>, mode: 'PUT' | 'POST', initialState: State<T> | T | undefined, onUpdate: (state: State<T>) => void) {
 
@@ -20,6 +21,7 @@ export default class ResourceLifecycle<T extends any> {
     }
     this.currentResource = resource;
     this.mode = mode;
+    this.onUpdate = onUpdate;
     if (!initialState) {
       this.currentState = null;
     } else if (isState(initialState as any)) {
@@ -50,7 +52,7 @@ export default class ResourceLifecycle<T extends any> {
       // We only need to call onUpdate for the 'POST' case
       // because the regular 'update' event will handle the event for
       // existing resources.
-      this.onUpdate(state);
+      this.update(state);
     }
 
   }
@@ -82,7 +84,7 @@ export default class ResourceLifecycle<T extends any> {
 
   public cleanup() {
 
-    this.currentResource.off('update', this.onUpdate);
+    this.currentResource.off('update', this.update);
 
   }
 
@@ -91,13 +93,14 @@ export default class ResourceLifecycle<T extends any> {
     if (this.mode === 'POST') {
       throw new Error('Update events cannot be subscribed to before the resource exists');
     }
-    this.currentResource.on('update', this.onUpdate);
+    this.currentResource.on('update', this.update);
 
   }
 
-  private onUpdate(state: State<T>) {
+  private update(state: State<T>) {
 
     this.currentState = state;
+    this.onUpdate(state);
 
   }
 

--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -40,6 +40,11 @@ export default class ResourceLifecycle<T> {
     if (this.mode === 'PUT') {
       // Update the Ketting cache too.
       this.currentResource.updateCache(state);
+    } else {
+      // We only need to call onUpdate for the 'POST' case
+      // because the regular 'update' event will handle the event for
+      // existing resources.
+      this.onUpdate(state);
     }
 
   }

--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -33,6 +33,8 @@ export default class ResourceLifecycle<T extends any> {
       this.setupEvents();
     }
 
+    this.update = this.update.bind(this);
+
   }
 
   async getState(): Promise<State<T>> {

--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -29,11 +29,14 @@ export default class ResourceLifecycle<T extends any> {
     } else {
       this.currentState = dataToState(initialState) as State<T>;
     }
+
+    // Rebind to 'this' so that 'this' will refer to the correct thing
+    // in the update function.
+    this.update = this.update.bind(this);
     if (mode === 'PUT') {
       this.setupEvents();
     }
 
-    this.update = this.update.bind(this);
 
   }
 

--- a/tslint.json
+++ b/tslint.json
@@ -19,7 +19,8 @@
       "object-literal-shorthand": false,
       "object-literal-sort-keys": false,
       "quotemark": [true, "single", "avoid-template", "avoid-escape"],
-      "trailing-comma": "never"
+      "trailing-comma": "never",
+      "unified-signatures": false
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
I added a new useReadResource hook, that's a simple hook for just reading the current Ketting state from a Resource and automatically re-render the component when there was an update.

This PR also rewrites useResource with all the discussed features from #5, but with a slightly different API.

This is how it's called now for new resources:

```typescript
const {
  loading,
  error,
  resourceState,
  setResourceState,
  submit,
} = useResource({
  resource: parentCollection,
  mode: 'POST',
  initialState: { title: 'New article', body: '...'}
});
```

For existing resources:

```typescript
const {
  loading,
  error,
  resourceState,
  setResourceState,
  submit,
} = useResource(resource);
```

This will need a lot of testing and is probably not correct on the first go.