### PR TITLE
Adding a 'provider' component.

### DIFF
--- a/src/hooks/use-client.ts
+++ b/src/hooks/use-client.ts
@@ -1,0 +1,14 @@
+import { useContext } from 'react';
+import { getKettingContext } from '../provider';
+import { Client } from 'ketting';
+
+export function useClient(): Client {
+
+  const kettingContext = useContext(getKettingContext());
+  if (!kettingContext.client) {
+    throw new Error('To use useClient, you must have a <KettingProvider> component set up');
+  }
+
+  return kettingContext.client;
+
+}

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -124,7 +124,6 @@ export function useResource<T>(arg1: Resource<T>|UseResourceOptions<T>|string): 
   }
 
 
-
   const isMounted = useRef(true);
 
   const [resourceState, setResourceState] = useState<ResourceState<T>>();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,5 @@
 export { useResource } from './hooks/use-resource';
 export { useReadResource } from './hooks/use-read-resource';
+export { getKettingContext, KettingProvider } from './provider';
+
 export { withResource } from './hoc';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,7 @@
 export { useResource } from './hooks/use-resource';
 export { useReadResource } from './hooks/use-read-resource';
+export { useClient } from './hooks/use-client';
+
 export { getKettingContext, KettingProvider } from './provider';
 
 export { withResource } from './hoc';

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { Client } from 'ketting';
+
+type Props = {
+  client: Client
+  children: React.ReactNode | React.ReactNode[] | null;
+};
+
+type KettingContext = {
+  client?: Client,
+};
+
+const KettingContext = React.createContext<KettingContext>({});
+
+export function getKettingContext(): React.Context<KettingContext> {
+  
+  return KettingContext;
+
+}
+
+export const KettingProvider: React.FC<Props> = ({client, children}) => {
+
+  const Context = getKettingContext();
+
+  const contextValue: KettingContext = {
+    client
+  };
+  return <Context.Provider value={contextValue}>
+    {children}
+  </Context.Provider>; 
+
+}


### PR DESCRIPTION
This component can propogate the ketting client via useContext throughout the application.

Usage in the root of your React app:

```typescript
import { Client } from 'ketting';
import { KettingProvider } from 'react-ketting';

const client = new Client();
const app = <App>
  <KettingProvider client={client} />
</App>
```

To get access to Client in your functional component:

```typescript
import { getClient } from 'react-ketting';

function MyComponent() {

  const client = useClient();

}
```

To get access to the client from Class components:

```typescript
import { getKettingContext } from 'react-ketting';

class MyComponent {
   static contextType = getKettingContext();

  render() {
     return 'hi';
  }

}
```

Using the Provider is optional, but when it's there, in the future you will be able to use the useResource hook in this way (not yet done)


```typescript
function MyCompnent {

   const { loading, error, data } = useResource('/url/to/my/thingy');

}
```

Basically it can allow you to specify urls instead of resource objects.

