### PR TITLE
Allow passing resources as promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ You can also setup Fetch middlewares:
 client.use( (request, next) => {
 
   request.headers.set('Authorization', 'Bar');
+  return next(request);
 
 });
 ```

--- a/README.md
+++ b/README.md
@@ -217,8 +217,14 @@ const { loading, error, data } = useResource({
 // Or with the Ketting client.
 const client = useClient();
 const resource = client.go('/article/1');
-const { loading, error, data } = useResource('/article/1');
+const { loading, error, data } = useResource(resource);
+
+// Or as the result of a promise
+const client = useClient();
+const resource = client.go('/article/1');
+const { loading, error, data } = useResource(resource.follow('author'));
 ```
+
 
 Return values:
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+0.7.0 (2020-06-22)
+------------------
+
+* `useResource()` can now take a URI argument instead of a Resource object.
+* `useResource()` can also take a Promise that resolves to a resource.
+* Added a `KettingProvider` component, giving any component access to the
+  closest Ketting client via `useContext` / `contextType`.
+* Added a `useClient` hook to easily find the Client object in functional
+  components.
+
+
+
 0.6.9 (2020-06-22)
 ------------------
 

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -6,7 +6,7 @@ type Props = {
   children: React.ReactNode | React.ReactNode[] | null;
 };
 
-type KettingContext = {
+export type KettingContext = {
   client?: Client,
 };
 

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -1,0 +1,19 @@
+import { Resource } from 'ketting';
+import { KettingContext } from './provider';
+
+export type ResourceLike<T> = Resource<T> | PromiseLike<Resource<T>> | string;
+
+export async function resolveResource<T>(res: ResourceLike<T>, kettingContext: KettingContext): Promise<Resource> {
+
+  if (typeof res === 'string') {
+
+    if (!kettingContext.client) {
+      throw new Error('In order to specify resources by their uri, a KettingProvider component must be set up');
+    }
+    return kettingContext.client.go(res);
+
+  }
+
+  return res;
+
+}


### PR DESCRIPTION
This will allow you to do something like this:

```typescript
const {loading, error, result} = useResource( parentResource.follow('item'))
```