### PR TITLE
Resource lifecycle bug.

### DIFF
--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -45,7 +45,7 @@ export default class ResourceLifecycle<T extends any> {
     if (!this.currentState) {
       this.currentState = await this.currentResource.get();
     }
-    return this.currentResource.get();
+    return this.currentState;
 
   }
 

--- a/src/resource-lifecycle.ts
+++ b/src/resource-lifecycle.ts
@@ -42,8 +42,8 @@ export default class ResourceLifecycle<T extends any> {
 
   async getState(): Promise<State<T>> {
 
-    if (this.currentState) {
-      return this.currentState;
+    if (!this.currentState) {
+      this.currentState = await this.currentResource.get();
     }
     return this.currentResource.get();
 


### PR DESCRIPTION
When fetching the current state from the server, the local 'resourcestate' was not updated in the lifecycle object.

This could cause setData to misbehave, as setData would now create a new 'resourceState' from scratch.