### PR TITLE
useCollection hook

### DIFF
--- a/src/hooks/use-collection.ts
+++ b/src/hooks/use-collection.ts
@@ -1,0 +1,120 @@
+import { Resource } from 'ketting';
+import { useState, useEffect, useContext } from 'react';
+import { getKettingContext } from '../provider';
+import { ResourceLike, resolveResource } from '../util';
+
+/**
+ * The result of a useCollection hook.
+ */
+type UseCollectionResponse<T> = {
+
+  /**
+   * True if there is no data or no error yet
+   */
+  loading: boolean;
+  
+  /**
+   * Will contain an Error object if an error occurred anywhere in the
+   */
+  error: Error | null;
+
+  /**
+   * List of collection members.
+   *
+   * This starts off as an empty array.
+   */
+  items: Resource<T>[];
+
+}
+
+/**
+ * Options that may be given to useCollection
+ */
+type UseCollectionOptions = {
+
+  /**
+   * By default useCollection will follow the 'item' relation type to find
+   * collection members.
+   *
+   * Change this option to follow a list of other links.
+   */
+  rel?: string;
+}
+
+/**
+ * The useCollection hook allows you to get a list of resources
+ * inside a collection.
+ *
+ * This hook makes a few assumptions:
+ *
+ * 1. The collection is some hypermedia document, such as HAL, HTML, Siren,
+ *    or anything Ketting supports.
+ * 2. The collection lists its members via 'item' web links.
+ *
+ * Example call:
+ *
+ * <pre>
+ *   const {
+ *     loading,
+ *     error,
+ *     items
+ *  } = useResource<Article>(resource);
+ * </pre>
+ *
+ * The resource may be passed as a Resource object, a Promise<Resource>, or a
+ * uri string.
+ *
+ * Returned properties:
+ *
+ * * loading - will be true as long as the result is still being fetched from
+ *             the server.
+ * * error - Will be null or an error object.
+ * * items - Will contain an array of resources, each typed Resource<T> where
+ *           T is the passed generic argument.
+ */
+export function useCollection<T>(resourceLike: ResourceLike<T>|string, options?: UseCollectionOptions): UseCollectionResponse<T> {
+
+  const rel = options?.rel || 'item';
+
+  const kettingContext = useContext(getKettingContext());
+  const [resource, setResource] = useState<Resource<T>|null>(
+    resourceLike instanceof Resource ? resourceLike : null
+  );
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<null|Error>(null);
+  const [items, setItems] = useState<Resource<T>[]>([]);
+
+  useEffect( () => {
+    if (!resource) {
+      // No real resource yet, let's find it.
+      resolveResource(resourceLike, kettingContext)
+        .then( res => { setResource(res); })
+        .catch( err => {
+          setError(err);
+          setLoading(false);
+        });
+      return;
+    }
+    // Now we got a resource, let's find its children.
+    resource
+      .followAll(rel)
+      .preferTransclude()
+      .then( result => {
+        setItems(result);
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(err);
+        setLoading(false);
+      });
+
+  }, [resource]);
+
+  return {
+    loading,
+    error,
+    items,
+  };
+
+}

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -25,6 +25,9 @@ type UseResourceResponse<T> = {
   // Update the data from the state.
   setData: (newData: T) => void;
 
+  // The 'real' resource.
+  resource: Resource<T>;
+
 }
 
 type UseResourceOptions<T> = {
@@ -157,6 +160,7 @@ export function useResource<T>(arg1: ResourceLike<T>|UseResourceOptions<T>|strin
       loading,
       error,
       resourceState: resourceState as ResourceState<T>,
+      resource: resource as Resource<T>,
       data: (resourceState ? resourceState.data : undefined) as T,
       setResourceState: (state: ResourceState<T>) => {
         throw new Error('Loading must complete before calling setResourceState');
@@ -179,6 +183,7 @@ export function useResource<T>(arg1: ResourceLike<T>|UseResourceOptions<T>|strin
       loading,
       error,
       resourceState: resourceState as ResourceState<T>,
+      resource: resource as Resource<T>,
       data: (resourceState ? resourceState.data : undefined) as T,
       setResourceState: (state: ResourceState<T>) => {
         return lifecycle.current!.setState(state);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
-export { useResource } from './hooks/use-resource';
-export { useReadResource } from './hooks/use-read-resource';
 export { useClient } from './hooks/use-client';
+export { useCollection } from './hooks/use-collection';
+export { useReadResource } from './hooks/use-read-resource';
+export { useResource } from './hooks/use-resource';
 
 export { getKettingContext, KettingProvider } from './provider';
 


### PR DESCRIPTION
Including reviewers mostly as 'fyi this is a thing'. Ignore if uninteresting.

The `useCollection` hook allows you to get a list of resources
inside a collection.

This hook makes a few assumptions:

1. The collection is some hypermedia document, such as HAL, HTML, Siren,
   or anything Ketting supports.
2. The collection lists its members via 'item' web links.

Example call:

```typescript
const {
  loading,
  error,
  items
} = useResource<Article>(resource);
```

The resource may be passed as a `Resource` object, a `Promise<Resource>`, or a
uri string.

Returned properties:

* loading - will be true as long as the result is still being fetched from
            the server.
* error - Will be null or an error object.
* items - Will contain an array of resources, each typed `Resource<T>` where
          `T` is the passed generic argument.

Bigger example:

```typescript
function MyCollection() {

  const {
    loading,
    error,
    items
  } = useCollection<Article>('/articles');

  if (loading) return <div>loading...</div>;
  if (error) return <div class="error">boo</div>;

  return <ul>{items.map(item => <MyCollectionItem resource={item} />)}</ul>

}

function MyCollectionItem({resource}: { resource: Resource<Article> }) {
  const {
    loading,
    error,
    data
  } = useResource(resource);

  if (loading) return <div>loading...</div>;
  if (error) return <div className="error">boo</div>;

  return <li>{data.title} - {data.body}</li>;

}
```

And because this connects with the event system throughout, if there's ever an update *somewhere else* in any of the resources, that will immediately get reflected in collection lists as well.

In the case of websockets, this means you'll see live updates to list items. (but not yet refreshes of the list itself, so deletes and inserts in the collection will be missed currently).

In the future I want to add support for automatically fetching the next page in a collection if there's a `next` link.