### PR TITLE
Guarantee re-render on resource state update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.3.2 (2020-11-12)
+------------------
+
+* Guarantee re-render on when `setData()` or `setResourceState()` is used.
+
+
 1.3.1 (2020-11-11)
 ------------------
 

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -149,7 +149,7 @@ export function useResource<T>(arg1: ResourceLike<T>|UseResourceOptions<T>|strin
 
     resource.get()
       .then(newState => {
-        setResourceState(newState);
+        setResourceState(newState.clone());
         setLoading(false);
       })
       .catch(err => {

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -128,7 +128,7 @@ export function useResource<T>(arg1: ResourceLike<T>|UseResourceOptions<T>|strin
     }
 
     const onUpdate = (newState: ResourceState<T>) => {
-      setResourceState(newState);
+      setResourceState(newState.clone());
       setLoading(false);
     };
     resource.on('update', onUpdate);
@@ -168,9 +168,9 @@ export function useResource<T>(arg1: ResourceLike<T>|UseResourceOptions<T>|strin
         throw new Error('Too early to call setResourceState, we don\'t have a current state to update');
       }
       if (modeVal === 'POST') {
-        setResourceState(newState.clone());
+        setResourceState(newState);
       } else {
-        resource.updateCache(newState.clone());
+        resource.updateCache(newState);
       }
     },
     resource: resource as Resource<T>,
@@ -194,9 +194,9 @@ export function useResource<T>(arg1: ResourceLike<T>|UseResourceOptions<T>|strin
       }
       resourceState.data = data;
       if (modeVal === 'POST') {
-        setResourceState(resourceState.clone());
+        setResourceState(resourceState);
       } else {
-        resource.updateCache(resourceState.clone());
+        resource.updateCache(resourceState);
       }
     }
 

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -168,9 +168,9 @@ export function useResource<T>(arg1: ResourceLike<T>|UseResourceOptions<T>|strin
         throw new Error('Too early to call setResourceState, we don\'t have a current state to update');
       }
       if (modeVal === 'POST') {
-        setResourceState(newState);
+        setResourceState(newState.clone());
       } else {
-        resource.updateCache(newState);
+        resource.updateCache(newState.clone());
       }
     },
     resource: resource as Resource<T>,
@@ -194,9 +194,9 @@ export function useResource<T>(arg1: ResourceLike<T>|UseResourceOptions<T>|strin
       }
       resourceState.data = data;
       if (modeVal === 'POST') {
-        setResourceState(resourceState);
+        setResourceState(resourceState.clone());
       } else {
-        resource.updateCache(resourceState);
+        resource.updateCache(resourceState.clone());
       }
     }
 


### PR DESCRIPTION
It's possible that a resourceState change does not trigger a re-render,
as it might have been the 'same' object that's emitted from the update
event.

By cloning the resourceState objects right before a render, we can avoid
this.