### PR TITLE
Bug in useCollection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.4.2 (2020-12-17)
+------------------
+
+* The 'type' of the result of useCollection is not dependent on the 'type'
+  of the collection that was passed it. This was a bug in `useCollection`.
+
+
 1.4.1 (2020-12-01)
 ------------------
 

--- a/src/hooks/use-collection.ts
+++ b/src/hooks/use-collection.ts
@@ -81,7 +81,7 @@ type UseCollectionOptions = {
  * * items - Will contain an array of resources, each typed Resource<T> where
  *           T is the passed generic argument.
  */
-export function useCollection<T>(resourceLike: ResourceLike<T>, options?: UseCollectionOptions): UseCollectionResponse<T> {
+export function useCollection<T = any>(resourceLike: ResourceLike<any>, options?: UseCollectionOptions): UseCollectionResponse<T> {
 
   const rel = options?.rel || 'item';
 


### PR DESCRIPTION
The 'type' of the result of useCollection is not dependent on the 'type'
of the collection that was passed it. This was a bug in `useCollection`.