### PR TITLE
Refactoring useReadResource, useResolveResource, useCollection

### DIFF
--- a/src/hooks/use-read-resource.ts
+++ b/src/hooks/use-read-resource.ts
@@ -1,112 +1,178 @@
-import { useState, useEffect, useRef, useContext } from 'react';
 import { Resource, State as ResourceState } from 'ketting';
-import { getKettingContext } from '../provider';
-import { ResourceLike ,resolveResource } from '../util';
+import { useState, useEffect } from 'react';
+import { ResourceLike } from '../util';
+import { useClient } from './use-client';
+import { Client } from 'ketting';
+import { useResolveResource } from './use-resolve-resource';
 
-type UseReadResourceResult<T> = {
+type UseReadResourceResponse<T> = {
 
-  /**
-   * 'true' if resource has not yet been fetched from the server.
-   */
-  loading: boolean,
-
-  /**
-   * Contains an Error object when an operation has failed.
-   */
-  error: Error|null,
+  // True if there is no data yet
+  loading: boolean;
+  error: Error | null;
 
   /**
-   * Full Ketting 'State' object.
+   * The ResourceState.
+   *
+   * Note that this will be `null` until loading is "false".
    */
-  resourceState: ResourceState<T>
+  resourceState: ResourceState<T>;
+
+  // The 'real' resource.
+  resource: Resource<T>;
+
 }
 
+export type UseReadResourceOptions<T> = {
+  resource: ResourceLike<T>,
+  initialState?: ResourceState<T>,
+  refreshOnStale?: boolean,
+
+  /**
+   * HTTP headers to include if there was no existing cache, and the initial
+   * GET request must be done to get the state.
+   *
+   * These headers are not used on subsequent refreshes/stale cases.
+   */
+  initialGetRequestHeaders?: Record<string, string>;
+
+};
+
 /**
- * Hook for fetching and subscribing to state changes on Ketting resources.
+ * The useReadResource hook is an internal hook that helps setting up a lot of
+ * the plumbing for dealing with resources and state.
  *
- * The hook returns an object with three properties:
- * 1. loading (boolean)
- * 2. error (Error|null)
- * 3. resourceState - A ketting State object.
+ * It's not recommended for external users to use this directly, instead use
+ * one of the more specialized hooks such as useResource or useCollection.
  *
- * The hook will automatically update its internal state if Ketting received
- * 'update' events.
- *
- * Example usage:
+ * Example call:
  *
  * <pre>
- *  function MyComponent(resource: Resource<Article>) {
- *
- *     const {loading, error, resourceState} = useReadResource(resource);
- *     if (loading) return <p>Loading...</p>;
- *     if (error) return <div class="error">Error: ${err.message}</div>
- *
- *     return <article>
- *       <h1>${resourceState.title}</h1>
- *       <p>${resoourceState.body}</p>
- *     </article>;
- *
- *  }
+ *   const {
+ *     loading,
+ *     error,
+ *     resourceState,
+ *  } = useResource(resource);
  * </pre>
  *
+ * Returned properties:
+ *
+ * * loading - will be true as long as the result is still being fetched from
+ *             the server.
+ * * error - Will be null or an error object.
+ * * resourceState - A state object. The `.data` property of this object will
+ *                   contain the parsed JSON from the server.
  */
-export function useReadResource<T>(resource: ResourceLike<T>): UseReadResourceResult<T> {
+export function useReadResource<T>(options: UseReadResourceOptions<T>): UseReadResourceResponse<T> {
 
-  const kettingContext = useContext(getKettingContext());
+  const { resource } = useResolveResource(options.resource);
 
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error|null>(null);
-  const [resourceState, setResourceState] = useState<ResourceState<T>>();
-  const [res, setRes] = useState<Resource<T>>();
+  const initialState = options.initialState;
+  const refreshOnStale = options.refreshOnStale || false;
+  const client = useClient();
 
-  const isMounted = useRef(true);
+  const [resourceState, setResourceState] = useResourceState(resource, initialState, client);
+  const [loading, setLoading] = useState(resourceState === undefined);
+  const [error, setError] = useState<null|Error>(null);
 
   useEffect(() => {
 
-    if (!res) {
-      resolveResource(resource, kettingContext)
-        .then( result => { setRes(result); })
-        .catch( err => {
-          setError(err);
-          setLoading(false);
-        });
+    // This effect is for setting up the onUpdate event
+    if (resource === null) {
       return;
     }
 
-    const onUpdate = useRef((state: ResourceState<T>) => {
-      if (isMounted.current) {
-        setResourceState(state);
-      }
-    });
-
-    (async() => {
-
-      const state = await res.get();
-      setResourceState(state);
+    const onUpdate = (newState: ResourceState<T>) => {
+      setResourceState(newState.clone());
       setLoading(false);
-
-      res.on('update', onUpdate.current);
-
-    })().catch(err => {
-
-      setLoading(false);
-      setError(err);
-
-    });
-
-    return function cleanup() {
-
-      isMounted.current = false;
-      res.off('update', onUpdate.current);
-
     };
 
-  }, [res]);
+    const onStale = () => {
+      if (refreshOnStale) {
+        resource
+          .refresh()
+          .catch(err => {
+            setError(err);
+          });
+      }
+    };
 
-  return {
+    resource.on('update', onUpdate);
+    resource.on('stale', onStale);
+
+    return function unmount() {
+      resource.off('update', onUpdate);
+      resource.off('stale', onStale);
+    };
+
+  }, [resource]);
+
+  useEffect(() => {
+
+    // This effect is for fetching the initial ResourceState
+    if (resource===null) {
+      // No need to fetch resourceState for these cases.
+      return;
+    }
+
+    if (resourceState && resourceState.uri === resource.uri) {
+      // Don't do anything if we already have a resourceState, and the
+      // resourceState's uri matches what we got.
+      return;
+    }
+
+    // The 'resource' property has changed, so lets get the new resourceState and data.
+    const cachedState = resource.client.cache.get(resource.uri);
+    if (cachedState) {
+      setResourceState(cachedState);
+      setLoading(false);
+      return;
+    } else {
+      setResourceState(undefined);
+      setLoading(true);
+    }
+
+    resource.get({ headers: options.initialGetRequestHeaders })
+      .then(newState => {
+        setResourceState(newState.clone());
+        setLoading(false);
+      })
+      .catch(err => {
+        setError(err);
+        setLoading(false);
+      });
+
+  }, [resource]);
+
+  const result = {
     loading,
     error,
-    resourceState: resourceState as ResourceState<T>
+    resourceState: resourceState as ResourceState<T>,
+    resource: resource as Resource<T>,
+    data: (resourceState?.data) as T,
   };
+
+  return result;
+
+}
+
+/**
+ * Internal helper hook to deal with setting up the resource state, and
+ * populate the cache.
+ */
+function useResourceState<T>(
+  resource: Resource<T> | null,
+  initialData: undefined | ResourceState<T>,
+  client: Client,
+): [ResourceState<T>|undefined, (rs: ResourceState<T>|undefined) => void] {
+
+  let data: undefined| ResourceState<T> = undefined;
+  if (initialData) {
+    data = initialData
+  } else if (resource instanceof Resource) {
+    data = client.cache.get(resource.uri) || undefined;
+  }
+  const [resourceState, setResourceState] = useState<ResourceState<T>| undefined>(data);
+  return [resourceState, setResourceState];
 
 }

--- a/src/hooks/use-resolve-resource.ts
+++ b/src/hooks/use-resolve-resource.ts
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react';
 type UseResolveResourceResult<T> = {
   error: Error | null,
   resource: Resource<T> | null,
+  setResource: (resource: Resource<T>) => void,
 }
 
 /**
@@ -37,7 +38,8 @@ export function useResolveResource<T>(resourceLike: ResourceLike<T>|string): Use
 
   return {
     resource,
-    error
+    error,
+    setResource,
   };
 
 }


### PR DESCRIPTION
There's a lot of logic shared between the hooks, and this is a first
step towards refactoring that a bit.

Originally the plan was to have a `useReadResource` that would be used
by both `useCollection` and `useResource`. This is useful, because a lot
of features like `refreshOnStale` has to be implemented twice. If there
were a more generic, fundemental hook that both `useResource` and
`useCollection` could use, this might potentially be a lot simpler.

So this is a first step towards doing that. useReadResource now listens
for events, and has some new options that make it good enough for
`useCollection`.

All `useCollection` now does is re-expose `useReadResource` but with an
`items` result that contains all the collection items. It's much simpler
now.

In the future I hope to refactor this further so `useResource` can also
undergo this same refactoring and become a lot simpler.

Until then all new features will still have to be implemented in two
places, but now its:

* useReadResource
* useResource