### PR TITLE
usePagedCollection

### DIFF
--- a/src/hooks/use-collection.ts
+++ b/src/hooks/use-collection.ts
@@ -30,7 +30,7 @@ type UseCollectionResponse<T> = {
 /**
  * Options that may be given to useCollection
  */
-type UseCollectionOptions = {
+export type UseCollectionOptions = {
 
   /**
    * By default useCollection will follow the 'item' relation type to find

--- a/src/hooks/use-paged-collection.ts
+++ b/src/hooks/use-paged-collection.ts
@@ -66,11 +66,14 @@ type UsePagedCollectionResponse<T> = {
  *
  * Returned properties:
  *
- * * loading - will be true as long as the result is still being fetched from
- *             the server.
+ * * loading - will be true every time we're going to the server and fetch a
+ *             a new page.
  * * error - Will be null or an error object.
  * * items - Will contain an array of resources, each typed Resource<T> where
  *           T is the passed generic argument.
+ * * hasNextPage - Will be true if the server has another page.
+ * * loadNextPage - Loads the next page, and appends the new items to the
+ *                  items array.
  */
 export function usePagedCollection<T = any>(resourceLike: ResourceLike<any>, options?: UseCollectionOptions): UsePagedCollectionResponse<T> {
 

--- a/src/hooks/use-paged-collection.ts
+++ b/src/hooks/use-paged-collection.ts
@@ -1,0 +1,130 @@
+import { Resource } from 'ketting';
+import { ResourceLike } from '../util';
+import { UseCollectionOptions } from './use-collection';
+import { useState, useEffect } from 'react';
+import { useReadResource } from './use-read-resource';
+
+/**
+ * The result of a useCollection hook.
+ */
+type UsePagedCollectionResponse<T> = {
+
+  /**
+   * True if we are loading the initial page, or additional pages.
+   */
+  loading: boolean;
+
+  /**
+   * Will contain an Error object if an error occurred anywhere in the
+   */
+  error: Error | null;
+
+  /**
+   * List of collection members.
+   *
+   * This starts off as an empty array.
+   */
+  items: Resource<T>[];
+
+  /**
+   * Will be set to true if there are more pages on the API.
+   */
+  hasNextPage: boolean;
+
+  /**
+   * Call this function to load the next page. If there are no next pages,
+   * a warning will be emitted.
+   */
+  loadNextPage: () => void;
+
+}
+
+/**
+ * The usePagedCollection hook works similar to useCollection, but has the
+ * ability to load in additional pages of items.
+ *
+ * For this to work, the API needs to expose a "next" link on the collection.
+ * As long as there are "next" links, more pages can be loaded in.
+ *
+ * Additional items from collection pages will be appended to "items",
+ * allowing frontends to build 'infinite scroll' features.
+ *
+ * Example call:
+ *
+ * <pre>
+ *   const {
+ *     loading,
+ *     error,
+ *     items,
+ *     hasNextPage,
+ *     loadNextPage
+ *  } = usePagedResource<Article>(resource);
+ * </pre>
+ *
+ * The resource may be passed as a Resource object, a Promise<Resource>, or a
+ * uri string.
+ *
+ * Returned properties:
+ *
+ * * loading - will be true as long as the result is still being fetched from
+ *             the server.
+ * * error - Will be null or an error object.
+ * * items - Will contain an array of resources, each typed Resource<T> where
+ *           T is the passed generic argument.
+ */
+export function usePagedCollection<T = any>(resourceLike: ResourceLike<any>, options?: UseCollectionOptions): UsePagedCollectionResponse<T> {
+
+  const rel = options?.rel || 'item';
+
+  const [items, setItems] = useState<Resource<T>[]>([]);
+  useEffect(() => {
+
+    // If 'resourceLike' changes, it means that we're starting with a new
+    // collection.
+    setItems([]);
+
+  },[resourceLike]);
+
+  const { resourceState, loading, error, setResource } = useReadResource({
+    resource: resourceLike,
+    refreshOnStale: options?.refreshOnStale,
+    // This header will be included on the first, uncached fetch.
+    // This may be helpful to the server and instruct it to embed
+    // all collection members in that initial fetch.
+    initialGetRequestHeaders: {
+      Prefer: 'transclude=' + rel,
+    }
+  });
+
+  useEffect( () => {
+
+    if (!resourceState) return;
+    setItems([
+      ...items,
+      ...resourceState.followAll(rel)
+    ]);
+
+  }, [resourceState]);
+
+
+  const hasNextPage =
+    resourceState && resourceState.links.has('next');
+
+  const loadNextPage = () => {
+
+    if (!hasNextPage) {
+      console.warn('loadNextPage was called, but there was no next page');
+    }
+    setResource(resourceState.follow('next'));
+
+  }
+
+  return {
+    loading,
+    error,
+    items,
+    hasNextPage,
+    loadNextPage,
+  };
+
+}

--- a/src/hooks/use-read-resource.ts
+++ b/src/hooks/use-read-resource.ts
@@ -18,8 +18,21 @@ type UseReadResourceResponse<T> = {
    */
   resourceState: ResourceState<T>;
 
-  // The 'real' resource.
+  /**
+   * The 'real' resource.
+   *
+   * This will be `null` until we have it. It's not typed null because it
+   * makes it very clumsy to work with the hook.
+   */
   resource: Resource<T>;
+
+  /**
+   * Change the resource that the hook uses.
+   *
+   * A reason you might want to do this is if the resource itself changed
+   * uris.
+   */
+  setResource(resource: Resource<T>): void;
 
 }
 
@@ -65,7 +78,7 @@ export type UseReadResourceOptions<T> = {
  */
 export function useReadResource<T>(options: UseReadResourceOptions<T>): UseReadResourceResponse<T> {
 
-  const { resource } = useResolveResource(options.resource);
+  const { resource, setResource } = useResolveResource(options.resource);
 
   const initialState = options.initialState;
   const refreshOnStale = options.refreshOnStale || false;
@@ -144,12 +157,12 @@ export function useReadResource<T>(options: UseReadResourceOptions<T>): UseReadR
 
   }, [resource]);
 
-  const result = {
+  const result: UseReadResourceResponse<T> = {
     loading,
     error,
     resourceState: resourceState as ResourceState<T>,
     resource: resource as Resource<T>,
-    data: (resourceState?.data) as T,
+    setResource,
   };
 
   return result;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 export { useClient } from './hooks/use-client';
 export { useCollection } from './hooks/use-collection';
+export { usePagedCollection } from './hooks/use-paged-collection';
 export { useReadResource } from './hooks/use-read-resource';
 export { useResolveResource } from './hooks/use-resolve-resource';
 export { useResource, UseResourceOptions } from './hooks/use-resource';


### PR DESCRIPTION
This hook is similar to `useCollection`, but it lets load in additional 
pages from a collection. The hook assumes that a "next" link relationship
exists on the collection.

Every time the next page is loaded, the new items from the new page are 
appended to the item list. This lets users do a 'infinite scroll' type 
interface.