### PR TITLE
Moving validateToken function above to prevent crashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "react-ketting",
       "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
@@ -19,7 +20,7 @@
         "@typescript-eslint/parser": "^4.17.0",
         "chai": "^4.3.4",
         "eslint": "^7.22.0",
-        "ketting": "^7.0.0",
+        "ketting": "^7.2.0",
         "mocha": "^9.0.1",
         "nyc": "^15.1.0",
         "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@typescript-eslint/parser": "^4.17.0",
     "chai": "^4.3.4",
     "eslint": "^7.22.0",
-    "ketting": "^7.0.0",
+    "ketting": "^7.2.0",
     "mocha": "^9.0.1",
     "nyc": "^15.1.0",
     "react": "^17.0.2",

--- a/src/components/RequireLogin.tsx
+++ b/src/components/RequireLogin.tsx
@@ -67,17 +67,6 @@ const RequireLogin: React.FC<Props> = (props: Props) => {
 
   const [isAuthenticated, setAuthenticated] = useState(false);
   const client = useClient();
-
-  useEffect(() => {
-    validateToken().catch(err => {
-      console.error('[ketting] Error while validating token', err);
-    });
-  }, [client]);
-
-  if (isAuthenticated) {
-    return <>{props.children}</>;
-  }
-
   const validateToken = async () => {
 
     const location = new URL(document.location.href);
@@ -159,6 +148,16 @@ const RequireLogin: React.FC<Props> = (props: Props) => {
     // IF we got here it means we didn't have tokens in LocalStorage, or they
     // were expired.
     document.location.href = getAuthorizeUri(props);
+  }
+
+  useEffect(() => {
+    validateToken().catch(err => {
+      console.error('[ketting] Error while validating token', err);
+    });
+  }, [client]);
+
+  if (isAuthenticated) {
+    return <>{props.children}</>;
   }
 
   /**


### PR DESCRIPTION
### Changes

The validateToken function gets called in useEffect, and in certain scenarios it is used before it is assigned and causes the react app to crash.

Also updated to use ketting v7.2.0 to match types