### PR TITLE
Hooks now are now consistent.

### DIFF
--- a/src/hooks/use-collection.ts
+++ b/src/hooks/use-collection.ts
@@ -85,8 +85,8 @@ export function useCollection<T = any>(resourceLike: ResourceLike<any>, options?
 
   const rel = options?.rel || 'item';
 
-  const { resourceState, loading, error } = useReadResource({
-    resource: resourceLike,
+  const { resourceState, loading, error } = useReadResource(resourceLike,
+    {
     refreshOnStale: options?.refreshOnStale,
     // This header will be included on the first, uncached fetch.
     // This may be helpful to the server and instruct it to embed

--- a/src/hooks/use-paged-collection.ts
+++ b/src/hooks/use-paged-collection.ts
@@ -84,8 +84,7 @@ export function usePagedCollection<T = any>(resourceLike: ResourceLike<any>, opt
   const [currentCollectionResource, setCurrentCollectionResource] = useState<ResourceLike<any>>(resourceLike);
 
   // This is the 'base collection'
-  const bc = useReadResource({
-    resource: resourceLike,
+  const bc = useReadResource(resourceLike, {
     refreshOnStale: options?.refreshOnStale,
     // This header will be included on the first, uncached fetch.
     // This may be helpful to the server and instruct it to embed
@@ -96,8 +95,7 @@ export function usePagedCollection<T = any>(resourceLike: ResourceLike<any>, opt
   });
 
   // This is the 'current collection
-  const cc = useReadResource({
-    resource: currentCollectionResource,
+  const cc = useReadResource(currentCollectionResource, {
     refreshOnStale: options?.refreshOnStale,
     // This header will be included on the first, uncached fetch.
     // This may be helpful to the server and instruct it to embed

--- a/src/hooks/use-read-resource.ts
+++ b/src/hooks/use-read-resource.ts
@@ -37,7 +37,6 @@ type UseReadResourceResponse<T> = {
 }
 
 export type UseReadResourceOptions<T> = {
-  resource: ResourceLike<T>,
   initialState?: ResourceState<T>,
   refreshOnStale?: boolean,
 
@@ -76,9 +75,9 @@ export type UseReadResourceOptions<T> = {
  * * resourceState - A state object. The `.data` property of this object will
  *                   contain the parsed JSON from the server.
  */
-export function useReadResource<T>(options: UseReadResourceOptions<T>): UseReadResourceResponse<T> {
+export function useReadResource<T>(resourceLike: ResourceLike<T>, options: UseReadResourceOptions<T>): UseReadResourceResponse<T> {
 
-  const { resource, setResource } = useResolveResource(options.resource);
+  const { resource, setResource } = useResolveResource(resourceLike);
 
   const initialState = options.initialState;
   const refreshOnStale = options.refreshOnStale || false;

--- a/src/hooks/use-resource.ts
+++ b/src/hooks/use-resource.ts
@@ -96,18 +96,18 @@ export type UseResourceOptions<T> = {
  * To do POST requests you must specifiy initialState with the state the user starts
  * off with.
  */
-export function useResource<T>(resourceLike: ResourceLike<T>|string, options: UseResourceOptions<T>): UseResourceResponse<T> {
+export function useResource<T>(resourceLike: ResourceLike<T>|string, options?: UseResourceOptions<T>): UseResourceResponse<T> {
 
   const [resource, setResource] = useState<Resource<T> | undefined>(resourceLike instanceof Resource ? resourceLike : undefined);
   const client = useClient();
   const [resourceState, setResourceState] = useResourceState(
     typeof resourceLike === 'string' ? client.go(resourceLike) : resourceLike,
-    options.initialState ?? undefined,
+    options?.initialState ?? undefined,
     client,
   );
   const [loading, setLoading] = useState(resourceState === undefined);
   const [error, setError] = useState<null|Error>(null);
-  const [modeVal, setModeVal] = useState<'POST' | 'PUT'>(options.mode ?? 'PUT');
+  const [modeVal, setModeVal] = useState<'POST' | 'PUT'>(options?.mode ?? 'PUT');
 
   useEffect(() => {
 
@@ -140,7 +140,7 @@ export function useResource<T>(resourceLike: ResourceLike<T>|string, options: Us
     };
 
     const onStale = () => {
-      if (options.refreshOnStale ?? false) {
+      if (options?.refreshOnStale ?? false) {
         resource
           .refresh()
           .catch(err => {


### PR DESCRIPTION
All hooks now have the same function signature:

```typescript
useFoo(resource, options)
```

This was already the case for `useCollection` and `usePagedCollection`,
but this has also been changed for `useResource`.

This is a breaking change. All calls such as the following stay the
same:

```typescript
useResource(resource);
useResource('/res');
useResource(Promise.resolve(resource));
```

But if options were used ,this syntax is no longer valid:

```typescript
useResource({
  resource: res,
  mode: 'POST',
  initialData: 'bla',
  refreshOnStale: true,
});
```

The `resource` has been moved out of the options object. The next syntax
is:

```typescript
useResource(res, {
  mode: 'POST',
  initialData: 'bla'
  refreshOnStale: true,
});
```

Given that this is a breaking change, this will be released as 3.0