### PR TITLE
Fix white screen of death if an updated string resourceLike is passed.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,8 @@ Changelog
 * In some cases when a React component passes a new resource as a string to
   useResource, the useResource might return "undefined" for the resource,
   which can result in a white screen of death.
-
+  This one was a bit of a doozy, check the PR for more information:
+  https://github.com/badgateway/react-ketting/pull/67
 
 2.1.4 (2021-09-01)
 ------------------

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,15 @@
 Changelog
 =========
 
-2.1.4 (2012-09-01)
+2.1.5 (2022-02-21)
+------------------
+
+* In some cases when a React component passes a new resource as a string to
+  useResource, the useResource might return "undefined" for the resource,
+  which can result in a white screen of death.
+
+
+2.1.4 (2021-09-01)
 ------------------
 
 * In some scenarios `RequireLogin` could crash due to a function sometimes

--- a/src/hooks/use-collection.ts
+++ b/src/hooks/use-collection.ts
@@ -83,6 +83,10 @@ export type UseCollectionOptions = {
  */
 export function useCollection<T = any>(resourceLike: ResourceLike<any>, options?: UseCollectionOptions): UseCollectionResponse<T> {
 
+  if (resourceLike===undefined) {
+    console.warn('useCollection was called with "undefined" as the "resourceLike" argument. This is a bug. Did you forget to wait for \'loading\' to complete somewhere?');
+  } 
+
   const rel = options?.rel || 'item';
 
   const { resourceState, loading, error } = useReadResource(resourceLike,


### PR DESCRIPTION
When useResource is called in re-renders, with an updated value for
'resourceLike', and that value has a type string, the useResource hook
might temporarily return 'undefined' for resource, while 'loading' is
false and 'error' is null.

Normally if that component gets a new resourceLike and needs to spend
time resolving it, it should make sure loading flips to 'true'.

However, if we get resourceLike as a string we can actually skip the
loading step altogether and immediately return the new resource.

This PR:

1. Fixes the bug
2. Skips a potential re-render
3. Re-uses code and removes some complexity
4. It adds a warning in case anything else accidentally sets `resourceLike` to undefined, hopefully making future debugging easier if end-users accidentally do this as well.