### PR TITLE
Renaming usePagedCollection to useInfiniteCollection

### DIFF
--- a/src/hooks/use-infinite-collection.ts
+++ b/src/hooks/use-infinite-collection.ts
@@ -40,7 +40,7 @@ type UsePagedCollectionResponse<T> = {
 }
 
 /**
- * The usePagedCollection hook works similar to useCollection, but has the
+ * The useInfiniteCollection hook works similar to useCollection, but has the
  * ability to load in additional pages of items.
  *
  * For this to work, the API needs to expose a "next" link on the collection.
@@ -58,7 +58,7 @@ type UsePagedCollectionResponse<T> = {
  *     items,
  *     hasNextPage,
  *     loadNextPage
- *  } = usePagedResource<Article>(resource);
+ *  } = useInfiniteResource<Article>(resource);
  * </pre>
  *
  * The resource may be passed as a Resource object, a Promise<Resource>, or a
@@ -75,7 +75,7 @@ type UsePagedCollectionResponse<T> = {
  * * loadNextPage - Loads the next page, and appends the new items to the
  *                  items array.
  */
-export function usePagedCollection<T = any>(resourceLike: ResourceLike<any>, options?: UseCollectionOptions): UsePagedCollectionResponse<T> {
+export function useInfiniteCollection<T = any>(resourceLike: ResourceLike<any>, options?: UseCollectionOptions): UsePagedCollectionResponse<T> {
 
   const rel = options?.rel || 'item';
 
@@ -149,5 +149,17 @@ export function usePagedCollection<T = any>(resourceLike: ResourceLike<any>, opt
     hasNextPage,
     loadNextPage,
   };
+
+}
+
+
+/**
+ * usePagedCollection is the deprecated old name for useInfiniteCollection
+ *
+ * @deprecated Rename to useInfiniteCollection
+ */
+export function usePagedCollection<T = any>(resourceLike: ResourceLike<any>, options?: UseCollectionOptions): UsePagedCollectionResponse<T> {
+
+  return useInfiniteCollection(resourceLike, options);
 
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 export { useClient } from './hooks/use-client';
 export { useCollection } from './hooks/use-collection';
-export { usePagedCollection } from './hooks/use-paged-collection';
+export { useInfiniteCollection, usePagedCollection } from './hooks/use-infinite-collection';
 export { useReadResource } from './hooks/use-read-resource';
 export { useResolveResource } from './hooks/use-resolve-resource';
 export { useResource, UseResourceOptions } from './hooks/use-resource';


### PR DESCRIPTION
The true reason for this is that I want to introduce a new hook later that lets user go from page to page, using previous and next buttons and pick page numbers.

Having both that hook, and this existing one means that there's 2 hooks that deal with pages, and we need good names for both. I feel that this existing hook would be better if it were called useInfiniteCollection, so this PR prepares for that change, without breaking BC.