### PR TITLE
Don't return a new 'items' property if nothing changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-ketting",
-  "version": "3.0.1",
+  "version": "3.0.1-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-ketting",
-      "version": "3.0.1",
+      "version": "3.0.1-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-ketting",
-  "version": "3.0.1-beta.0",
+  "version": "3.0.2-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-ketting",
-      "version": "3.0.1-beta.0",
+      "version": "3.0.2-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^4.2.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "3.0.1",
+  "version": "3.0.1-beta.0",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ketting",
-  "version": "3.0.1-beta.0",
+  "version": "3.0.2-beta.0",
   "description": "Ketting bindings for React",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/use-collection.ts
+++ b/src/hooks/use-collection.ts
@@ -121,7 +121,7 @@ export function useCollection<T = any>(resourceLike: ResourceLike<any>, options?
   return {
     loading,
     error,
-    items: items,
+    items,
     resource,
     resourceState,
   };

--- a/src/hooks/use-collection.ts
+++ b/src/hooks/use-collection.ts
@@ -1,5 +1,5 @@
 import { Resource, State as ResourceState } from 'ketting';
-import { useRef } from 'react';
+import { useMemo } from 'react';
 import { ResourceLike } from '../util';
 import { useReadResource } from './use-read-resource';
 
@@ -113,21 +113,15 @@ export function useCollection<T = any>(resourceLike: ResourceLike<any>, options?
       }
     });
 
-  const items = useRef<Resource<T>[]>([]);
-  const prevResourceState = useRef<ResourceState<T> | null>(null);
-
-  if (resourceState && prevResourceState.current !== resourceState) {
-
-    // followAll always returns a new array. We only want to set a new items
-    // array if resourceState changed.
-    items.current = resourceState.followAll(rel);
-    prevResourceState.current = resourceState;
-  }
+  const items = useMemo(() => {
+    if (!resourceState) return [];
+    return resourceState.followAll(rel);
+  }, [resourceState]);
 
   return {
     loading,
     error,
-    items: items.current,
+    items: items,
     resource,
     resourceState,
   };

--- a/src/hooks/use-collection.ts
+++ b/src/hooks/use-collection.ts
@@ -1,4 +1,4 @@
-import { Resource, State } from 'ketting';
+import { Resource, State as ResourceState } from 'ketting';
 import { useRef } from 'react';
 import { ResourceLike } from '../util';
 import { useReadResource } from './use-read-resource';
@@ -36,7 +36,7 @@ type UseCollectionResponse<T> = {
    *
    * This gives you access to that underlying data.
    */
-  resourceState: State<T>;
+  resourceState: ResourceState<T>;
 
 }
 
@@ -114,8 +114,14 @@ export function useCollection<T = any>(resourceLike: ResourceLike<any>, options?
     });
 
   const items = useRef<Resource<T>[]>([]);
-  if (resourceState) {
+  const prevResourceState = useRef<ResourceState<T> | null>(null);
+
+  if (resourceState && prevResourceState.current !== resourceState) {
+
+    // followAll always returns a new array. We only want to set a new items
+    // array if resourceState changed.
     items.current = resourceState.followAll(rel);
+    prevResourceState.current = resourceState;
   }
 
   return {


### PR DESCRIPTION
`useCollection` returns a fresh array for the `items` property for every call, even if the contents didn't change.

This is no fun if you want to use `items` in a dependency array for useEffect, and can cause unnecessary re-renders. 