### PR TITLE
Re-export all Ketting symbols in react-ketting

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+// Hooks!
 export { useClient } from './hooks/use-client';
 export { useCollection } from './hooks/use-collection';
 export { useInfiniteCollection, usePagedCollection } from './hooks/use-infinite-collection';
@@ -8,8 +9,13 @@ export { useNewResource } from './hooks/use-new-resource';
 
 export { getKettingContext, KettingProvider } from './provider';
 
+// HoCs
 export { withResource } from './hoc';
 
+// Utility
 export { ResourceLike } from './util';
 
 export { RequireLogin } from './components/RequireLogin';
+
+// Reexport from Ketting
+export * from 'ketting';


### PR DESCRIPTION
No more wondering if you need to import something from the 'ketting' or 'react-ketting' package.