### PR TITLE
Reduce the number of renders in useCollection, useResource

### DIFF
--- a/src/hooks/use-read-resource.ts
+++ b/src/hooks/use-read-resource.ts
@@ -138,17 +138,13 @@ export function useReadResource<T>(resourceLike: ResourceLike<T>, options: UseRe
     if (cachedState) {
       setResourceState(cachedState);
       setLoading(false);
+
       return;
-    } else {
-      setResourceState(undefined);
-      setLoading(true);
     }
+    setResourceState(undefined);
+    setLoading(true);
 
     resource.get({ headers: options.initialGetRequestHeaders })
-      .then(newState => {
-        setResourceState(newState.clone());
-        setLoading(false);
-      })
       .catch(err => {
         setError(err);
         setLoading(false);

--- a/test/hooks/use-read-resource.tsx
+++ b/test/hooks/use-read-resource.tsx
@@ -35,8 +35,13 @@ describe('useReadResource', () => {
 
     await waitFor(() => screen.getByText('Hello world'));
 
-    // 2 renders is aspirational. Currently this is 5 :(
-    //expect(renderCount).to.eql(2);
+    // Currently this is 3 renders, but in React 18 apparently this should
+    // automatically drop to 2 due to batch state updates.
+    //
+    // The reason it's 3 renders currently is becaused setLoading and
+    // setResourceState each cause a render even though they are called
+    // immediately after each other.
+    expect(renderCount).to.be.lessThan(4);
 
   });
 
@@ -65,8 +70,7 @@ describe('useReadResource', () => {
     screen.getByText('Loading');
 
     await waitFor(() => screen.getByText('Error!'));
-    // 2 renders is aspirational. Currently this is 5 :(
-    //expect(renderCount).to.eql(2);
+    expect(renderCount).to.be.lessThan(4);
 
   });
 


### PR DESCRIPTION
Before this change `useReadResource` rendered 5 times from a cold cache. After this change this is 3.

`useReadResource` is used by all of these other hooks, which now also have their number of renders reduced by 2

* `useCollection`
* `useResource`
* `useInfiniteCollection`
* `useNewResource`

This change also reduces memory and should make everything a tad faster because we were doing a bunch of unnecessary work. Specifically the `ResourceState` objects were cloned once more than needed.

In the future it will be possible to get the 3 down to 2.

The reason it's currently 3 renders is because there's a few places that update 2 state variables in a row, looking like this:

```typescript
setResourceState(true)
setLoading(false)
```

To my surprise, even if these statements happen immediately after each other, these changes are not batched and cause 2 renders immediately after each other.

We *could* fix this by refactoring the hooks and combining `loading` and `resourceState` in a single combined state variable, but this will require a refactor.

Apparently React 18 will start batching these, so my assumption is that everyone will go from 3 to 2 renders once React 18 drops. See: https://github.com/reactwg/react-18/discussions/21

With this change I also consider #64 done.

Fixes #64