### PR TITLE
Adding a <SelectLink> component.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   },
   "nyc": {
     "extension": [
-      ".ts"
+      ".ts",
+      ".tsx"
     ]
   },
   "mocha": {

--- a/src/components/SelectLink.tsx
+++ b/src/components/SelectLink.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { ResourceLike } from '../util';
+import { useReadResource } from '../hooks/use-read-resource';
+
+type Props = {
+  resource: ResourceLike<any>;
+  rel?: string;
+} & React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export function SelectLink(prop: Props) {
+
+  const {resource, rel, ...selectProps} = prop;
+  const { resourceState, loading, error } = useReadResource(resource, {});
+
+  if (loading) {
+    return <select {...selectProps}><option disabled>Loading...</option></select>;
+  }
+  if (error) throw error;
+
+  const links = resourceState.links.getMany(rel ?? 'item');
+
+  return <select {...selectProps}>
+    {selectProps.children}
+    {links.map(link => {
+      return <option value={link.href} key={link.href}>{link.title}</option>;
+    })}
+  </select>;
+
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ export { withResource } from './hoc';
 export { ResourceLike } from './util';
 
 export { RequireLogin } from './components/RequireLogin';
+export { SelectLink } from './components/SelectLink';
 
 // Reexport from Ketting
 export * from 'ketting';

--- a/test/component/SelectLink.tsx
+++ b/test/component/SelectLink.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { render, screen, storeInCache, waitFor} from '../test-utils';
+
+import { SelectLink } from '../../src';
+
+describe('<SelectLink />', () => {
+
+  storeInCache('/select-link-1', {
+    _links: {
+      item: [
+        { href: '/foo-1', title: 'Option 1'},
+        { href: '/foo-2', title: 'Option 2'},
+      ]
+    }
+  });
+  storeInCache('/select-link-2', {}, { status: 403 });
+
+  it('Should render', async () => {
+
+    render(<SelectLink resource="/select-link-1" />);
+    screen.getByText('Loading...');
+
+    await waitFor(() => screen.getByText('Option 1'));
+
+    // 2 renders is aspirational. Currently this is 5 :(
+    //expect(renderCount).to.eql(2);
+
+  });
+
+});


### PR DESCRIPTION
Adding a `<SelectLink>` component.

This is a pattern I noticed I've had to do more than a few times, and it made sense to make a default component for this.

All this does right now is render a `<select>` with a list of links. The label is taken from the link title, and the uri is used for the value.

It's possible to add an empty option like this:

```html
<SelectLink resource="/some-collection">
  <option value="">Please select an option</option>
</SelectLink>
```