### PR TITLE
Refresh 'infinite collection' completely when parent state changes.

### DIFF
--- a/src/hooks/use-infinite-collection.ts
+++ b/src/hooks/use-infinite-collection.ts
@@ -56,8 +56,6 @@ type UsePagedCollectionResponse<T> = {
  *     loading,
  *     error,
  *     items,
- *     hasNextPage,
- *     loadNextPage
  *  } = useInfiniteResource<Article>(resource);
  * </pre>
  *
@@ -113,7 +111,7 @@ export function useInfiniteCollection<T = any>(resourceLike: ResourceLike<any>, 
     // Set the 'current' page back to the first page in the collection.
     setCurrentCollectionResource(resourceLike);
 
-  }, [bc.resource]);
+  }, [bc.resourceState]);
 
   useEffect(() => {
 


### PR DESCRIPTION
When 'refreshOnStale' is true in `useInfiniteCollection`, and the main collection refreshes, nothing happened as if `refreshOnStale` was ignored.

This PR fixes this problem. When this happens, the entire base collection now completely resets its state.

Fixes #87