### PR TITLE
Fix refreshOnStale for useInfiniteCollection with only 1 page.

### DIFF
--- a/src/hooks/use-infinite-collection.ts
+++ b/src/hooks/use-infinite-collection.ts
@@ -124,7 +124,7 @@ export function useInfiniteCollection<T = any>(resourceLike: ResourceLike<any>, 
       ]);
     }
 
-  }, [cc.resourceState?.uri]);
+  }, [cc.resourceState?.uri, bc.resourceState]);
 
 
   const hasNextPage =


### PR DESCRIPTION
If only 1 page is loaded, then the 'current page' is the same as the first page.

When the collection is refreshed, the `useEffect` hook that populates the page data doesn't detect the change, so the collection stays empty after the reload.